### PR TITLE
fix protobuf for cura-build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,10 +253,17 @@ if(INSTALL_PYTHON)
 	DEPENDS protoc
     )
     add_custom_target(python_protobuf ALL DEPENDS python/google)
-    install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/python/google
-        DESTINATION lib/python3.4/site-packages
-        COMPONENT protobuf_lib
-    )
+    if(APPLE OR WIN32)
+        install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/python/google
+            DESTINATION lib/python3.4/site-packages
+            COMPONENT protobuf_lib
+        )
+    else()
+        install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/python/google
+            DESTINATION lib/python3.4/dist-packages
+            COMPONENT protobuf_lib
+        )
+    endif()
 endif()
 
 foreach(file ${PB_HEADER_FILES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,7 +254,7 @@ if(INSTALL_PYTHON)
     )
     add_custom_target(python_protobuf ALL DEPENDS python/google)
     install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/python/google
-        DESTINATION lib/python3.4/dist-packages
+        DESTINATION lib/python3.4/site-packages
         COMPONENT protobuf_lib
     )
 endif()

--- a/src/google/protobuf/unittest_proto3_arena.proto
+++ b/src/google/protobuf/unittest_proto3_arena.proto
@@ -43,7 +43,7 @@ message TestAllTypes {
     // The field name "b" fails to compile in proto1 because it conflicts with
     // a local variable named "b" in one of the generated methods.  Doh.
     // This file needs to compile in proto1 to test backwards-compatibility.
-    optional int32 bb = 1;
+     int32 bb = 1;
   }
 
   enum NestedEnum {
@@ -55,46 +55,43 @@ message TestAllTypes {
   }
 
   // Singular
-  optional    int32 optional_int32    =  1;
-  optional    int64 optional_int64    =  2;
-  optional   uint32 optional_uint32   =  3;
-  optional   uint64 optional_uint64   =  4;
-  optional   sint32 optional_sint32   =  5;
-  optional   sint64 optional_sint64   =  6;
-  optional  fixed32 optional_fixed32  =  7;
-  optional  fixed64 optional_fixed64  =  8;
-  optional sfixed32 optional_sfixed32 =  9;
-  optional sfixed64 optional_sfixed64 = 10;
-  optional    float optional_float    = 11;
-  optional   double optional_double   = 12;
-  optional     bool optional_bool     = 13;
-  optional   string optional_string   = 14;
-  optional    bytes optional_bytes    = 15;
+      int32 _int32    =  1;
+      int64 _int64    =  2;
+     uint32 _uint32   =  3;
+     uint64 _uint64   =  4;
+     sint32 _sint32   =  5;
+     sint64 _sint64   =  6;
+    fixed32 _fixed32  =  7;
+    fixed64 _fixed64  =  8;
+   sfixed32 _sfixed32 =  9;
+   sfixed64 _sfixed64 = 10;
+      float _float    = 11;
+     double _double   = 12;
+       bool _bool     = 13;
+     string _string   = 14;
+      bytes _bytes    = 15;
 
-  optional group OptionalGroup = 16 {
-    optional int32 a = 17;
-  }
 
-  optional NestedMessage                        optional_nested_message  = 18;
-  optional ForeignMessage                       optional_foreign_message = 19;
-  optional protobuf_unittest_import.ImportMessage optional_import_message  = 20;
+   NestedMessage                        _nested_message  = 18;
+   ForeignMessage                       _foreign_message = 19;
+   protobuf_unittest_import.ImportMessage _import_message  = 20;
 
-  optional NestedEnum                           optional_nested_enum     = 21;
-  optional ForeignEnum                          optional_foreign_enum    = 22;
+   NestedEnum                           _nested_enum     = 21;
+   ForeignEnum                          _foreign_enum    = 22;
 
   // Omitted (compared to unittest.proto) because proto2 enums are not allowed
   // inside proto2 messages.
   //
-  // optional protobuf_unittest_import.ImportEnum    optional_import_enum  = 23;
+  //  protobuf_unittest_import.ImportEnum    _import_enum  = 23;
 
-  optional string optional_string_piece = 24 [ctype=STRING_PIECE];
-  optional string optional_cord = 25 [ctype=CORD];
+   string _string_piece = 24 [ctype=STRING_PIECE];
+   string _cord = 25 [ctype=CORD];
 
   // Defined in unittest_import_public.proto
-  optional protobuf_unittest_import.PublicImportMessage
-      optional_public_import_message = 26;
+   protobuf_unittest_import.PublicImportMessage
+      _public_import_message = 26;
 
-  optional NestedMessage optional_lazy_message = 27 [lazy=true];
+   NestedMessage _lazy_message = 27 [lazy=true];
 
   // Repeated
   repeated    int32 repeated_int32    = 31;
@@ -112,10 +109,6 @@ message TestAllTypes {
   repeated     bool repeated_bool     = 43;
   repeated   string repeated_string   = 44;
   repeated    bytes repeated_bytes    = 45;
-
-  repeated group RepeatedGroup = 46 {
-    optional int32 a = 47;
-  }
 
   repeated NestedMessage                        repeated_nested_message  = 48;
   repeated ForeignMessage                       repeated_foreign_message = 49;
@@ -170,7 +163,7 @@ message NestedTestAllTypes {
 // Define these after TestAllTypes to make sure the compiler can handle
 // that.
 message ForeignMessage {
-  optional int32 c = 1;
+   int32 c = 1;
 }
 
 enum ForeignEnum {


### PR DESCRIPTION
The current Ultimaker/protobuf master seems to not work correctly with Ultimaker/cura-build master. 

1. on OSX, the python package is installed into dist-packages, but python only searches in site-packages
2. the explicit "optional" keywords and "groups" don't seem to be supported by that version of protobuf, hence the unit test fails

This pull request fixes both of these issues so that I can produce a working app with the cura-build master branch.